### PR TITLE
:sparkles: add init containers support to KuberntesPodOperator

### DIFF
--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -50,6 +50,8 @@ class KubernetesPodOperator(BaseOperator):
     :type volume_mounts: list[airflow.contrib.kubernetes.volume_mount.VolumeMount]
     :param volumes: volumes for launched pod. Includes ConfigMaps and PersistentVolumes
     :type volumes: list[airflow.contrib.kubernetes.volume.Volume]
+    :param init_containers: init containers for launched pod.
+    :type init_containers: list[airflow.contrib.kubernetes.init_container.InitContainer]
     :param labels: labels to apply to the Pod
     :type labels: dict
     :param startup_timeout_seconds: timeout in seconds to startup the pod
@@ -101,44 +103,51 @@ class KubernetesPodOperator(BaseOperator):
     """
     template_fields = ('cmds', 'arguments', 'env_vars', 'config_file')
 
+    def _create_pod(self, gen):
+        for port in self.ports:
+            gen.add_port(port)
+        for mount in self.volume_mounts:
+            gen.add_mount(mount)
+        for volume in self.volumes:
+            gen.add_volume(volume)
+        for init_container in self.init_containers:
+            gen.add_init_container(init_container)
+
+        pod = gen.make_pod(
+            namespace=self.namespace,
+            image=self.image,
+            pod_id=self.name,
+            cmds=self.cmds,
+            arguments=self.arguments,
+            labels=self.labels,
+        )
+
+        pod.service_account_name = self.service_account_name
+        pod.secrets = self.secrets
+        pod.envs = self.env_vars
+        pod.image_pull_policy = self.image_pull_policy
+        pod.image_pull_secrets = self.image_pull_secrets
+        pod.annotations = self.annotations
+        pod.resources = self.resources
+        pod.affinity = self.affinity
+        pod.node_selectors = self.node_selectors
+        pod.hostnetwork = self.hostnetwork
+        pod.tolerations = self.tolerations
+        pod.configmaps = self.configmaps
+        pod.security_context = self.security_context
+        pod.pod_runtime_info_envs = self.pod_runtime_info_envs
+        pod.dnspolicy = self.dnspolicy
+        return pod
+
     def execute(self, context):
         try:
             client = kube_client.get_kube_client(in_cluster=self.in_cluster,
-                                                 cluster_context=self.cluster_context,
-                                                 config_file=self.config_file)
+                                    cluster_context=self.cluster_context,
+                                    config_file=self.config_file)
+
             gen = pod_generator.PodGenerator()
 
-            for port in self.ports:
-                gen.add_port(port)
-            for mount in self.volume_mounts:
-                gen.add_mount(mount)
-            for volume in self.volumes:
-                gen.add_volume(volume)
-
-            pod = gen.make_pod(
-                namespace=self.namespace,
-                image=self.image,
-                pod_id=self.name,
-                cmds=self.cmds,
-                arguments=self.arguments,
-                labels=self.labels,
-            )
-
-            pod.service_account_name = self.service_account_name
-            pod.secrets = self.secrets
-            pod.envs = self.env_vars
-            pod.image_pull_policy = self.image_pull_policy
-            pod.image_pull_secrets = self.image_pull_secrets
-            pod.annotations = self.annotations
-            pod.resources = self.resources
-            pod.affinity = self.affinity
-            pod.node_selectors = self.node_selectors
-            pod.hostnetwork = self.hostnetwork
-            pod.tolerations = self.tolerations
-            pod.configmaps = self.configmaps
-            pod.security_context = self.security_context
-            pod.pod_runtime_info_envs = self.pod_runtime_info_envs
-            pod.dnspolicy = self.dnspolicy
+            pod = self._create_pod(gen)
 
             launcher = pod_launcher.PodLauncher(kube_client=client,
                                                 extract_xcom=self.do_xcom_push)
@@ -177,6 +186,7 @@ class KubernetesPodOperator(BaseOperator):
                  ports=None,
                  volume_mounts=None,
                  volumes=None,
+                 init_containers=None,
                  env_vars=None,
                  secrets=None,
                  in_cluster=False,
@@ -214,6 +224,7 @@ class KubernetesPodOperator(BaseOperator):
         self.ports = ports or []
         self.volume_mounts = volume_mounts or []
         self.volumes = volumes or []
+        self.init_containers = init_containers or []
         self.secrets = secrets or []
         self.in_cluster = in_cluster
         self.cluster_context = cluster_context

--- a/airflow/kubernetes/init_container.py
+++ b/airflow/kubernetes/init_container.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+class InitContainer:
+    """Defines Kubernetes Init Container"""
+
+    def __init__(self, name, image, security_context, init_environment=None, volume_mounts=None):
+        """Initialize a Kubernetes Init Container. Used for setup Pods.
+        :param name: the name of the volume mount
+        :type name: str
+        :param image:
+        :type image: str
+        :param security_context: subpath within the volume mount
+        :type security_context: dict
+        :param init_environment: whether to access pod with read-only mode
+        :type init_environment: dict
+        :param volume_mounts: whether to access pod with read-only mode
+        :type volume_mounts: dict
+        """
+        self.name = name
+        self.image = image
+        self.security_context = security_context
+        self.init_environment = init_environment or {}
+        self.volume_mounts = volume_mounts or {}

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -18,6 +18,7 @@
 from airflow.kubernetes.pod import Pod, Port
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
+from airflow.kubernetes.init_container import InitContainer
 import uuid
 
 
@@ -31,7 +32,24 @@ class PodGenerator:
         self.volume_mounts = []
         self.init_containers = []
 
-    def add_init_container(self,
+    def add_init_container(self, init_container: InitContainer):
+        """
+
+        Adds an init container to the launched pod. useful for pre-
+
+        :param: init_container: init container definition
+        :type: init_container: airflow.kubernetes.init_container.InitContainer
+
+        """
+        self._add_init_container(
+            name=init_container.name,
+            image=init_container.image,
+            security_context=init_container.security_context,
+            init_environment=init_container.init_environment,
+            volume_mounts=init_container.volume_mounts
+        )
+
+    def _add_init_container(self,
                            name,
                            image,
                            security_context,


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.
  - In case you are proposing a fundamental code change, you need to create an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)).
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release

### Code Quality

- [ ] Passes `flake8`
